### PR TITLE
fix: support 2FA with ERR_MUST_USE_OTC_ANOMALOUS_LOGIN error code

### DIFF
--- a/src/dojo-api.ts
+++ b/src/dojo-api.ts
@@ -67,7 +67,9 @@ export class DojoAPI {
           // Access the error payload
           const structuredResponse = error.response.data as ErrorResponse;
 
-          if (structuredResponse.error.type === 401 && structuredResponse.error.code === "ERR_MUST_USE_OTC_USER_OPTED_IN") {
+          if (structuredResponse.error.type === 401 && 
+              (structuredResponse.error.code === "ERR_MUST_USE_OTC_USER_OPTED_IN" || 
+               structuredResponse.error.code === "ERR_MUST_USE_OTC_ANOMALOUS_LOGIN")) {
             console.log(structuredResponse.error.fallbackMessage);
 
             // Prompt for the one-time code


### PR DESCRIPTION
### Description

The 2FA prompt was never displayed because the code only handled ERR_MUST_USE_OTC_USER_OPTED_IN, but ClassDojo API returns  ERR_MUST_USE_OTC_ANOMALOUS_LOGIN for anomalous login detection.

Now handles both error codes to properly trigger 2FA flow.